### PR TITLE
[FEAT] Drawer 컴포넌트, 스토리북

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -30,6 +30,8 @@ jobs:
 
   add_reviewers:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -29,6 +29,7 @@ jobs:
           config-file-name: labeler-config.yaml
 
   add_reviewers:
+    if: github.actor != 'coderabbitai[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/src/shared/constants/motion.ts
+++ b/src/shared/constants/motion.ts
@@ -4,3 +4,16 @@ export const MODAL_MOTION = {
   exit: { opacity: 0 },
   transition: { duration: 0.3 },
 };
+
+export const FADE_IN_ANIMATION = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+};
+
+export const SLIDE_IN_ANIMATION = {
+  initial: { translateX: '100%' },
+  animate: { translateX: 0 },
+  exit: { translateX: '100%' },
+  transition: { type: 'tween', damping: 50 },
+};

--- a/src/shared/model/useModal.ts
+++ b/src/shared/model/useModal.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+export const useModal = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  return {
+    isOpen,
+    openModal: handleOpen,
+    closeModal: handleClose,
+  };
+};

--- a/src/shared/model/usePortal.ts
+++ b/src/shared/model/usePortal.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export const useModal = () => {
+export const usePortal = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleOpen = () => setIsOpen(true);

--- a/src/shared/ui/Drawer/Drawer.stories.tsx
+++ b/src/shared/ui/Drawer/Drawer.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useModal } from '@/shared/model/useModal';
+
+import { Drawer, Props } from './Drawer';
+
+import { Button } from '../Button';
+import { Title1 } from '../Typography';
+
+const meta = {
+  title: 'components/common/Drawer',
+  component: Drawer,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Drawer>;
+
+export default meta;
+
+export type Story = StoryObj<Props>;
+export const Basic: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+  },
+  argTypes: {
+    onClose: { action: 'onClose' },
+  },
+  render: () => {
+    const { isOpen, openModal, closeModal } = useModal();
+
+    return (
+      <>
+        <Button variant="primary" color="blue" onClick={openModal}>
+          Open Drawer
+        </Button>
+        <Drawer isOpen={isOpen} onClose={closeModal}>
+          <div className="p-32">
+            <Title1>Drawer</Title1>
+          </div>
+        </Drawer>
+      </>
+    );
+  },
+};

--- a/src/shared/ui/Drawer/Drawer.stories.tsx
+++ b/src/shared/ui/Drawer/Drawer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { useModal } from '@/shared/model/useModal';
+import { usePortal } from '@/shared/model/usePortal';
 
 import { Drawer, Props } from './Drawer';
 
@@ -25,7 +25,7 @@ export const Basic: Story = {
     onClose: { action: 'onClose' },
   },
   render: () => {
-    const { isOpen, openModal, closeModal } = useModal();
+    const { isOpen, openModal, closeModal } = usePortal();
 
     return (
       <>

--- a/src/shared/ui/Drawer/Drawer.tsx
+++ b/src/shared/ui/Drawer/Drawer.tsx
@@ -1,0 +1,42 @@
+import { PropsWithChildren } from 'react';
+import { motion } from 'framer-motion';
+
+import { FADE_IN_ANIMATION, SLIDE_IN_ANIMATION } from '@/shared/constants/motion';
+
+import { Portal } from '../Portal';
+
+export type Props = {
+  /**
+   * The open state of the drawer.
+   */
+  isOpen: boolean;
+  /**
+   * The function to call when the drawer is closed.
+   */
+  onClose: () => void;
+} & PropsWithChildren;
+
+export function Drawer({ isOpen, onClose, children }: Props) {
+  return (
+    <Portal isOpen={isOpen}>
+      <motion.div
+        onClick={onClose}
+        className="fixed inset-0 bg-black/50"
+        initial={FADE_IN_ANIMATION.initial}
+        animate={FADE_IN_ANIMATION.animate}
+        exit={FADE_IN_ANIMATION.exit}
+      />
+      <div className="fixed right-0 top-0 z-50 h-full">
+        <motion.div
+          className="h-full bg-white shadow-lg"
+          initial={SLIDE_IN_ANIMATION.initial}
+          animate={SLIDE_IN_ANIMATION.animate}
+          exit={SLIDE_IN_ANIMATION.exit}
+          transition={SLIDE_IN_ANIMATION.transition}
+        >
+          {children}
+        </motion.div>
+      </div>
+    </Portal>
+  );
+}

--- a/src/shared/ui/Drawer/index.tsx
+++ b/src/shared/ui/Drawer/index.tsx
@@ -1,0 +1,1 @@
+export { Drawer } from './Drawer';


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 🔥 연관 이슈

- close #40

## 🚀 작업 내용

- Drawer 컴포넌트 작업했습니다. motion에 관해 여러분들의 수고로움을 덜어들이기 위해 정리 해봤습니닷

**SLIDE_IN_ANIMATION**
- `initial : translateX: 100%` : 드로어 패널이 화면 오른쪽 바깥에 위치합니다. 
- `animate : translateX: 0` : 패널이 오른쪽에서 화면 안으로 미끄러져 들어옵니다.
- `exit : translateX: 100%` : 패널이 다시 오른쪽으로 미끄러져 나갑니다.
- `transition: { type: 'tween', damping: 50 },` : 애니메이션 방식을 정의한 것입니다. [tween](https://codesandbox.io/p/sandbox/framer-motion-tween-vs-spring-vs-inertia-1ws2o?file=%2Fsrc%2FApp.js) 은 일반적으로 선형(x/y 변경) 애니메이션에서 많이 쓰인다고 해서 적용했습니다! `damping: 50`은 저항도(?)라고 알고 있어요!

**FADE_IN_ANIMATION**
- `initial : opacity: 0` : 배경이 투명한 상태입니다.
- `animate : opacity: 1` : 배경이 불투명해집니다.
- `exit : opacity: 0` : 드로어가 닫힐 때 배경이 다시 투명해집니다.

결국 **드로어가 열릴 때**는 투명한 상태에서 점점 어두워지는 효과가 (fade-in) 나타나는 동시에 오른쪽 바깥에서 왼쪽으로 드로워가 미끄러져 들어오게(slide-in) 됩니다.
**드로어가 닫힐 때는**어두운 상태에서 점점 투명해지면서 요소가 사라지고(fade-out) 동시에 화면에서 오른쪽 바깥으로 미끄러져 나가게(slide-out) 됩니당

![Apr-08-2025 18-50-10](https://github.com/user-attachments/assets/189432df-19b4-4324-a5dd-254d8ea1bf2b)

## 🤔 고민했던 내용

- `FADE`, `SLIDE` 애니메이션을 통해 생동감을 주려고 노력했어요. 사용 중 불편하거나 염려되는 부분 있다면 의견 부탁드립니다~!
- 내부 요소 만큼 `width`를 가지면 좋을 것 같아서 따로 지정하지 않았습니다.

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 부드러운 전환 효과를 제공하는 페이드 인 및 슬라이드 인 애니메이션 추가
	- 인터랙티브한 Drawer 컴포넌트 도입으로 모달 창 기능 향상 (열기 및 닫기 동작 포함)
	- Drawer 컴포넌트의 동작을 시연할 수 있는 인터랙티브 데모 환경 제공
	- 사용자 경험 개선을 위한 모달 상태 관리 기능 추가
	- Drawer 컴포넌트를 다른 모듈에서 쉽게 사용할 수 있도록 내보내기 추가
- **작업**
	- GitHub 워크플로우에서 풀 리퀘스트에 대한 쓰기 권한 추가
	- 특정 봇에 대한 작업 실행 조건 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->