### PR TITLE
[FIX] Typography 컴포넌트 다형성 추가

### DIFF
--- a/src/shared/ui/Typography/Typography.tsx
+++ b/src/shared/ui/Typography/Typography.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef, createElement, ReactNode } from 'react';
+import { ComponentPropsWithoutRef, createElement, ReactNode } from 'react';
 import { cva } from 'class-variance-authority';
 
 import { cn } from '@/shared/lib/core';

--- a/src/shared/ui/Typography/Typography.tsx
+++ b/src/shared/ui/Typography/Typography.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 import { cva } from 'class-variance-authority';
 
 import { cn } from '@/shared/lib/core';
@@ -19,10 +19,12 @@ type TypographyVariant =
   | 'ButtonTitle1'
   | 'ButtonTitle2';
 
-type Props = {
+type TypographyProps = {
   variant: TypographyVariant;
   className?: string;
-} & ComponentPropsWithoutRef<'p'>;
+  as?: React.ElementType;
+  children: React.ReactNode;
+} & ComponentPropsWithoutRef<'div' | 'span' | 'label' | 'p'>;
 
 const variantClasses = cva('whitespace-pre-wrap', {
   variants: {
@@ -48,20 +50,26 @@ const variantClasses = cva('whitespace-pre-wrap', {
   },
 });
 
-function Typography({ children, variant = 'Body1', className = '', ...props }: Props) {
+function Typography({
+  children,
+  variant = 'Body1',
+  className = '',
+  as: Component = 'p',
+  ...props
+}: TypographyProps) {
   return (
-    <p className={cn(variantClasses({ type: variant }), className)} {...props}>
+    <Component className={cn(variantClasses({ type: variant }), className)} {...props}>
       {children}
-    </p>
+    </Component>
   );
 }
 
-function createTypography(variant: TypographyVariant) {
-  function Component(props: Omit<Props, 'variant'>) {
+const createTypography = (variant: TypographyVariant) => {
+  function TypographyComponent(props: Omit<TypographyProps, 'variant'>) {
     return <Typography variant={variant} {...props} />;
   }
-  return Component;
-}
+  return TypographyComponent;
+};
 
 export const Title1 = createTypography('Title1');
 export const Title2 = createTypography('Title2');
@@ -77,3 +85,17 @@ export const Caption1 = createTypography('Caption1');
 export const Caption2 = createTypography('Caption2');
 export const ButtonTitle1 = createTypography('ButtonTitle1');
 export const ButtonTitle2 = createTypography('ButtonTitle2');
+
+type TypographyComponentProps<T extends React.ElementType> = {
+  as?: T;
+  children: React.ReactNode;
+} & ComponentPropsWithoutRef<T>;
+
+export function TypographyComponent<T extends React.ElementType = 'p'>({
+  as,
+  children,
+  ...props
+}: TypographyComponentProps<T>) {
+  const Component = as || 'p';
+  return <Component {...props}>{children}</Component>;
+}

--- a/src/shared/ui/Typography/Typography.tsx
+++ b/src/shared/ui/Typography/Typography.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef } from 'react';
+import React, { ComponentPropsWithoutRef, createElement, ReactNode } from 'react';
 import { cva } from 'class-variance-authority';
 
 import { cn } from '@/shared/lib/core';
@@ -18,13 +18,6 @@ type TypographyVariant =
   | 'Caption2'
   | 'ButtonTitle1'
   | 'ButtonTitle2';
-
-type TypographyProps = {
-  variant: TypographyVariant;
-  className?: string;
-  as?: React.ElementType;
-  children: React.ReactNode;
-} & ComponentPropsWithoutRef<'div' | 'span' | 'label' | 'p'>;
 
 const variantClasses = cva('whitespace-pre-wrap', {
   variants: {
@@ -50,25 +43,38 @@ const variantClasses = cva('whitespace-pre-wrap', {
   },
 });
 
-function Typography({
+type AllowedTag = 'p' | 'div' | 'label' | 'span';
+
+type TypographyProps<T extends AllowedTag> = {
+  as?: T;
+  className?: string;
+  children?: ReactNode;
+  variant?: TypographyVariant;
+} & Omit<ComponentPropsWithoutRef<T>, 'as' | 'className' | 'children'>;
+
+export function Typography<T extends AllowedTag = 'p'>({
+  as,
+  className,
   children,
-  variant = 'Body1',
-  className = '',
-  as: Component = 'p',
   ...props
-}: TypographyProps) {
-  return (
-    <Component className={cn(variantClasses({ type: variant }), className)} {...props}>
-      {children}
-    </Component>
+}: TypographyProps<T>) {
+  const Component = as || 'p';
+
+  return createElement(
+    Component,
+    {
+      className: cn(variantClasses({ type: props.variant }), className),
+      ...props,
+    } as ComponentPropsWithoutRef<T>,
+    children
   );
 }
 
 const createTypography = (variant: TypographyVariant) => {
-  function TypographyComponent(props: Omit<TypographyProps, 'variant'>) {
+  function Component<T extends AllowedTag = 'p'>(props: Omit<TypographyProps<T>, 'variant'>) {
     return <Typography variant={variant} {...props} />;
   }
-  return TypographyComponent;
+  return Component;
 };
 
 export const Title1 = createTypography('Title1');

--- a/src/shared/ui/Typography/Typography.tsx
+++ b/src/shared/ui/Typography/Typography.tsx
@@ -91,17 +91,3 @@ export const Caption1 = createTypography('Caption1');
 export const Caption2 = createTypography('Caption2');
 export const ButtonTitle1 = createTypography('ButtonTitle1');
 export const ButtonTitle2 = createTypography('ButtonTitle2');
-
-type TypographyComponentProps<T extends React.ElementType> = {
-  as?: T;
-  children: React.ReactNode;
-} & ComponentPropsWithoutRef<T>;
-
-export function TypographyComponent<T extends React.ElementType = 'p'>({
-  as,
-  children,
-  ...props
-}: TypographyComponentProps<T>) {
-  const Component = as || 'p';
-  return <Component {...props}>{children}</Component>;
-}

--- a/src/shared/ui/Typography/Typography.tsx
+++ b/src/shared/ui/Typography/Typography.tsx
@@ -65,7 +65,7 @@ export function Typography<T extends AllowedTag = 'p'>({
     {
       className: cn(variantClasses({ type: props.variant }), className),
       ...props,
-    } as ComponentPropsWithoutRef<T>,
+    },
     children
   );
 }


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 🔥 연관 이슈

- close #35 

## 🚀 작업 내용
`'p' , 'div' , 'label' , 'span'` 태그를 `as`로 받을 수 있도록 추가하였습니다! 

## 🤔 고민했던 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Typography 컴포넌트가 이제 `as` 속성을 지원하여 다양한 HTML 태그(`p`, `div`, `label`, `span`)로 렌더링할 수 있습니다.

- **Refactor**
  - Typography 컴포넌트 구조가 개선되어 태그와 스타일 변형(variant)이 분리되었습니다.
  - 범용적으로 사용할 수 있는 폴리모픽 타이포그래피 컴포넌트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->