### PR TITLE
[FEAT] Card 컴포넌트, 스토리북 작성

### DIFF
--- a/src/shared/ui/Card/Card.stories.tsx
+++ b/src/shared/ui/Card/Card.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Card } from './Card';
+
+const meta = {
+  title: 'components/common/Card',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Card 컴포넌트는 동아리 소개, 동아리 점수, 활동보고서 회차 등에서 사용되는 컨테이너입니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  args: {
+    children: '카드 컴포넌트',
+  },
+  argTypes: {
+    as: {
+      control: false,
+    },
+    className: {
+      control: false,
+    },
+  },
+  render: (args) => {
+    return <Card {...args} />;
+  },
+};

--- a/src/shared/ui/Card/Card.tsx
+++ b/src/shared/ui/Card/Card.tsx
@@ -12,7 +12,7 @@ export type Props<T extends ElementType> = {
    * Additional CSS classNames to be applied to the Card.
    */
   className?: string;
-} & PropsWithChildren<ComponentProps<'div'>>;
+} & PropsWithChildren<ComponentProps<T>>;
 
 export function Card<T extends ElementType = 'div'>({
   as,

--- a/src/shared/ui/Card/Card.tsx
+++ b/src/shared/ui/Card/Card.tsx
@@ -1,0 +1,36 @@
+import { ComponentProps, PropsWithChildren, ElementType } from 'react';
+
+import { cn } from '@/shared/lib/core';
+
+export type Props<T extends ElementType> = {
+  /**
+   * The HTML element or React component to render as the root element.
+   * @defaults 'div'.
+   */
+  as?: T;
+  /**
+   * Additional CSS classNames to be applied to the Card.
+   */
+  className?: string;
+} & PropsWithChildren<ComponentProps<'div'>>;
+
+export function Card<T extends ElementType = 'div'>({
+  as,
+  className,
+  children,
+  ...props
+}: Props<T>) {
+  const Component = as || 'div';
+
+  return (
+    <Component
+      className={cn(
+        'box-border rounded-xl border border-gray-200 bg-white px-[22px] py-6 transition-colors hover:bg-gray-50',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/src/shared/ui/Card/index.ts
+++ b/src/shared/ui/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card } from './Card';


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 🔥 연관 이슈

- close #42

## 🚀 작업 내용

- 이전에 논의되었던 Card 컴포넌트를 디자이너 분들께서 padding이 통합된 형태로 재디자인해 주셨습니다. [이전 논의 노션 링크](https://www.notion.so/Card-feec0250e41f412fbfebf0495c1468b5?source=copy_link)
- 컴포넌트 전반에 걸쳐 padding값이 통일 되었습니다.

## 🤔 고민했던 내용
- 다형성 적용 여부에 대해 고민했습니다. 이전에 사용하던 `ClubCard` 컴포넌트는 `li` 태그로 구현되었고, 활동보고서 페이지에서는 `Link` 태그로 사용되는 등 상황에 따라 태그가 달라지는 경우가 있어 다형성을 제공하는 것이 적절하다고 판단되어 적용했습니다.

## 💬 리뷰 중점사항

- 현재는 단순한 컨테이너 역할로 사용되고 있지만, 추가되면 좋을 기능이나 개선 사항 있다면 피드백 주시면 감사하겠습니다! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새로운 재사용 가능한 Card 컴포넌트가 추가되었습니다. 다양한 컨텐츠를 담는 컨테이너로 활용할 수 있습니다.
  * Card 컴포넌트의 Storybook 스토리가 추가되어, UI 테스트 및 미리보기가 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->